### PR TITLE
Fix stray gtag script URL encoding

### DIFF
--- a/home.html
+++ b/home.html
@@ -26,7 +26,7 @@
   <meta property="og:image:height" content="630">
   <meta name="theme-color" content="#ebebeb">
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }

--- a/pages/about.html
+++ b/pages/about.html
@@ -31,7 +31,7 @@
     <!-- Google tag (gtag.js) -->
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -31,7 +31,7 @@
     <!-- Google tag (gtag.js) -->
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/pages/play-ground.html
+++ b/pages/play-ground.html
@@ -31,7 +31,7 @@
     <!-- Google tag (gtag.js) -->
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/pages/works.html
+++ b/pages/works.html
@@ -24,7 +24,7 @@
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }

--- a/works/eislab.html
+++ b/works/eislab.html
@@ -31,7 +31,7 @@
     <!-- Google tag (gtag.js) -->
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/works/kin.html
+++ b/works/kin.html
@@ -31,7 +31,7 @@
     <!-- Google tag (gtag.js) -->
     <script
       async
-      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM%22%3E"
+      src="https://www.googletagmanager.com/gtag/js?id=G-EM3JMY7NKM"
     ></script>
     <script>
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary
- fix Google Tag Manager script URL in all HTML files

## Testing
- `git status --short`