### PR TITLE
Fix absolute link to playground

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -223,7 +223,7 @@
             <a
               data-splitting
               data-menu="playground"
-              href="play-ground.html"
+              href="/play-ground.html"
               class="menu__link"
             >
               <p class="menu__number">03</p>


### PR DESCRIPTION
## Summary
- ensure `pages/about.html` uses an absolute path for Playground navigation links

## Testing
- `grep -n "play-ground" pages/about.html`